### PR TITLE
nvme: add atomic write support

### DIFF
--- a/hw/nvme/ns.c
+++ b/hw/nvme/ns.c
@@ -95,6 +95,20 @@ static int nvme_ns_init(NvmeNamespace *ns, Error **errp)
 
     id_ns->mc = NVME_ID_NS_MC_EXTENDED | NVME_ID_NS_MC_SEPARATE;
 
+    /* Atomic */
+    if (ns->params.atomic_nsfeat) {
+	id_ns->nsfeat |= 0x2;
+	id_ns->nawun = ns->params.atomic_nawun;
+	id_ns->nawupf = ns->params.atomic_nawupf;
+	id_ns->nacwu = ns->params.atomic_nacwu;
+    }
+    id_ns->nabsn = ns->params.atomic_nabsn;
+    id_ns->nabo = ns->params.atomic_nabo;
+    id_ns->nabspf = ns->params.atomic_nabspf;
+    id_ns->noiob = ns->params.atomic_noiob;
+
+    printf("Atomic Paramters: NAWUN=%d NAWUPF=%d NABSN=%d NABSPF=%d NABO=%d\n", id_ns->nawun, id_ns->nawupf, id_ns->nabsn, id_ns->nabspf, id_ns->noiob);
+
     if (ms && ns->params.mset) {
         id_ns->flbas |= NVME_ID_NS_FLBAS_EXTENDED;
     }
@@ -138,7 +152,6 @@ static int nvme_ns_init(NvmeNamespace *ns, Error **errp)
     ns->nlbaf++;
 
     id_ns->flbas |= i;
-
 
 lbaf_found:
     id_ns_nvm->elbaf[i] = (ns->pif & 0x3) << 7;
@@ -707,6 +720,13 @@ static void nvme_ns_realize(DeviceState *dev, Error **errp)
         ns->endgrp = &subsys->endgrp;
     }
 
+    if (n->params.atomic_dn) {
+	n->params.atomic_awun = 0;
+        n->params.atomic_acwu = 0;
+        ns->params.atomic_nawun = 0;
+        ns->params.atomic_nacwu = 0;
+    }
+
     if (nvme_ns_setup(ns, errp)) {
         return;
     }
@@ -792,6 +812,14 @@ static Property nvme_ns_props[] = {
     DEFINE_PROP_BOOL("eui64-default", NvmeNamespace, params.eui64_default,
                      false),
     DEFINE_PROP_STRING("fdp.ruhs", NvmeNamespace, params.fdp.ruhs),
+    DEFINE_PROP_UINT16("atomic.nawun", NvmeNamespace, params.atomic_nawun, 0),
+    DEFINE_PROP_UINT16("atomic.nawupf", NvmeNamespace, params.atomic_nawupf, 0),
+    DEFINE_PROP_UINT16("atomic.nacwu", NvmeNamespace, params.atomic_nacwu, 0),
+    DEFINE_PROP_UINT16("atomic.nabsn", NvmeNamespace, params.atomic_nabsn, 0),
+    DEFINE_PROP_UINT16("atomic.nabo", NvmeNamespace, params.atomic_nabo, 0),
+    DEFINE_PROP_UINT16("atomic.nabspf", NvmeNamespace, params.atomic_nabspf, 0),
+    DEFINE_PROP_UINT16("atomic.noiob", NvmeNamespace, params.atomic_noiob, 0),
+    DEFINE_PROP_BOOL("atomic.nsfeat", NvmeNamespace, params.atomic_nsfeat, 0),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/nvme/nvme.h
+++ b/hw/nvme/nvme.h
@@ -197,6 +197,15 @@ typedef struct NvmeNamespaceParams {
     struct {
         char *ruhs;
     } fdp;
+    bool     atomic_nsabp;
+    uint16_t atomic_nawun;
+    uint16_t atomic_nawupf;
+    uint16_t atomic_nacwu;
+    uint16_t atomic_nabsn;
+    uint16_t atomic_nabo;
+    uint16_t atomic_nabspf;
+    uint16_t atomic_noiob;
+    bool     atomic_nsfeat;
 } NvmeNamespaceParams;
 
 typedef struct NvmeNamespace {
@@ -515,6 +524,17 @@ typedef struct NvmeParams {
     uint16_t sriov_vi_flexible;
     uint8_t  sriov_max_vq_per_vf;
     uint8_t  sriov_max_vi_per_vf;
+    bool     atomic_dn;
+    uint16_t  atomic_awun;
+    uint16_t  atomic_awupf;
+    uint16_t  atomic_acwu;
+    uint16_t  atomic_nawun;
+    uint16_t  atomic_nawupf;
+    uint16_t  atomic_nacwu;
+    uint16_t  atomic_nabsn;
+    uint16_t  atomic_nabo;
+    uint16_t  atomic_nabspf;
+    uint16_t  atomic_noiob;
 } NvmeParams;
 
 typedef struct NvmeCtrl {
@@ -597,6 +617,9 @@ typedef struct NvmeCtrl {
         uint16_t    vqrfap;
         uint16_t    virfap;
     } next_pri_ctrl_cap;    /* These override pri_ctrl_cap after reset */
+    uint32_t    dn; /* Disable Normal */
+    int		atomic_writes;
+    QemuMutex atomic_lock;
 } NvmeCtrl;
 
 typedef enum NvmeResetType {


### PR DESCRIPTION
This patch can be applied to test the Linux Atomic Writes feature on a QEMU emulated NVMe device.

The following parameters have been added.  These parameters correspond to registers defined by the NVMe Specification related to atomic writes. See the NVMe Specification for definitions of the registers/parameters.

-device nvme,serial=<serial>,id=<bus_name>, \
               cmb_size_mb=<cmb_size_mb[optional]>, \
               [pmrdev=<mem_backend_file_id>,] \
               max_ioqpairs=<N[optional]>, \
               aerl=<N[optional]>,aer_max_queued=<N[optional]>, \
               mdts=<N[optional]>,vsl=<N[optional]>, \
               zoned.zasl=<N[optional]>, \
               zoned.auto_transition=<on|off[optional]>, \
               sriov_max_vfs=<N[optional]> \
               sriov_vq_flexible=<N[optional]> \
               sriov_vi_flexible=<N[optional]> \
               sriov_max_vi_per_vf=<N[optional]> \
               sriov_max_vq_per_vf=<N[optional]> \
               subsys=<subsys_id> \
+              atomic.dn=<on|off[optional]> \
+              atomic.awun=<N[optional]> \
+              atomic.awupf=<N[optional]> \
+              atomic.acwu=<N[optional]>
       -device nvme-ns,drive=<drive_id>,bus=<bus_name>,nsid=<nsid>,\
               zoned=<true|false[optional]>, \
               subsys=<subsys_id>,detached=<true|false[optional]> \
+              atomic.nsfeat=<on|off[optional]> \
+              atomic.nawun=<N[optional]> \
+              atomic.nawupf=<N[optional]> \
+              atomic.nacwu=<N[optional]> \
+              atomic.nabsn=<N[optional]> \
+              atomic.nabo=<N[optional]> \
+              atomic.nabspf=<N[optional]> \
+              atomic.noiob0<N[optional]>

QEMU will display messages when an issued write breaks the atomicity rules either by write size of crossing an atomic boundary.